### PR TITLE
check that export is not undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function (fn) {
         // be an object with the default export as a property of it. To ensure
         // the existing api and babel esmodule exports are both supported we
         // check for both
-        if (exp === fn || exp.default === fn) {
+        if (exp && (exp === fn || exp.default === fn)) {
             key = i;
             break;
         } else if (wrapperFuncString.indexOf(fnString) > -1) {


### PR DESCRIPTION
when exp is undefined, `exp.default` throws error
