### PR TITLE
Catch more reformatted anonymous function patterns

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function (fn) {
       // FF adds a "use strict"; to the function body
       .replace(/"use strict";\n\n/, '')
       // Browsers also slightly reformat the minified function expression
-      .replace(/^function \((.*)\)\{(\n"use strict";\n)?/, 'function($1){')
+      .replace(/^function\s?\((.*)\)(\s?)\{(\n"use strict";\n)?/, 'function($1)$2{')
 
     var sourcesKeys = Object.keys(sources); // when using the CommonChunks plugin, webpacl sometimes storing sources in object instead of array
 


### PR DESCRIPTION
I found some additional cases where anonymous functions weren't being caught.

This case was on OSX, Chrome 51.0.2704.103, as used by [mapbox/mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js/blob/master/js/source/worker.js#L17):

``` javascript
module.exports = function(self) {
    return new Worker(self);
};
```

In this case, `fn.toString()` was

```
function (self) {
    return new Worker(self);
}
```

whereas `sources[i].toString()` contained

```
function(self) {
    return new Worker(self);
};
```

The new regex will match the space between `) {` if it exists and replace it with the match, accommodating both styles.

Related:
- https://github.com/mapbox/mapbox-gl-js/pull/2857
- #10 
