### PR TITLE
Fix issues with duplicate module hits, and with inconsistent spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var __webpack_require__ = arguments[2];
 var sources = __webpack_require__.m;
+var webworkifyWebpackModuleId = arguments[0].id;
 
 var webpackBootstrapFunc = function(modules) {
     var installedModules = {};
@@ -23,15 +24,20 @@ var webpackBootstrapFunc = function(modules) {
     return f.default || f; // try to call default if defined to also support babel esmodule exports
 }
 
+// http://stackoverflow.com/a/2593661/130442
+function quoteRegExp(str) {
+    return (str+'').replace(/[.?*+^$[\]\\(){}|-]/g, "\\$&");
+}
+
 module.exports = function (fn) {
-    var fnString = fn.toString()
-      // FF adds a "use strict"; to the function body
-      .replace(/"use strict";\n\n/, '')
-      // Browsers also slightly reformat the minified function expression
-      .replace(/^function\s?\((.*)\)(\s?)\{(\n"use strict";\n)?/, 'function($1)$2{')
+    var moduleWrapperStrings = [];
+    var potentialFnModuleIds = [];
 
     var sourcesKeys = Object.keys(sources); // when using the CommonChunks plugin, webpacl sometimes storing sources in object instead of array
 
+
+    // first, find the modules that required webworkify-webpack, and note their requires so that we can limit the number of potential duplicate matches
+    // while we're at it, save the string version for use later
     var key;
     for (var i = 0, l = sourcesKeys.length; i < l; i++) {
         var k = sourcesKeys[i];
@@ -39,31 +45,65 @@ module.exports = function (fn) {
             continue;
         }
         var wrapperFuncString = sources[k].toString();
+        moduleWrapperStrings[k] = wrapperFuncString;
 
-        // Being the first to require a file can be dangerous if a module has
-        // assumptions about when it is initialized. By looking to see if the
-        // `fnString` is in the module first, we can avoid unnecessary requires.
-        if (wrapperFuncString.indexOf(fnString) > -1) {
-            key = i;
-            var exp = __webpack_require__(i);
-
-            // Using babel as a transpiler to use esmodule, the export will always
-            // be an object with the default export as a property of it. To ensure
-            // the existing api and babel esmodule exports are both supported we
-            // check for both
-            if (!(exp && (exp === fn || exp.default === fn))) {
-              sources[k] = wrapperFuncString.substring(0, wrapperFuncString.length - 1) + '\n' + fnString.match(/function\s?(.+?)\s?\(.*/)[1] + '();\n}';
-            }
-            break;
+        // __webpack_require__ is the third argument passed to the wrapper function, but it may have been renamed by minification
+        var wrapperSignature = wrapperFuncString.match(/^function\s?\(\w+,\s*\w+,\s*(\w+)\)/);
+        if (!wrapperSignature) {
+          // no matches means the module doesn't use __webpack_require__, and we can skip it entirely
+          continue;
         }
+
+        var webpackRequireName = wrapperSignature[1];
+        if (wrapperFuncString.indexOf(webpackRequireName + '(' + webworkifyWebpackModuleId + ')') > -1) {
+            // find all calls that look like __webpack_require__(\d+), and aren't webworkify-webpack
+            var re = new RegExp(quoteRegExp(webpackRequireName) + '\\((\\d+)\\)', 'g');
+            var match;
+            while (match = re.exec(wrapperFuncString)) {
+                if (match[1] != ('' + webworkifyWebpackModuleId)) {
+                    potentialFnModuleIds.push(match[1]);
+                }
+            }
+        }
+    }
+
+    var fnString = fn.toString()
+        // FF adds a "use strict"; to the function body
+        .replace(/"use strict";\n\n/, '');
+
+    var fnStringNoSpace = fnString
+        .replace(/^function\s?\((.*)\)(\s?)\{(\n"use strict";\n)?/, 'function($1)$2{');
+    var fnStringWithSpace = fnString
+        .replace(/^function\s?\((.*)\)(\s?)\{(\n"use strict";\n)?/, 'function ($1)$2{');
+
+    // find the first moduleId from the above list that contains fnString
+    var key = potentialFnModuleIds.find(function (moduleId) {
+        var wrapperFuncString = sources[moduleId].toString();
+        if (wrapperFuncString.indexOf(fnStringNoSpace) > -1 || wrapperFuncString.indexOf(fnStringWithSpace) > -1) {
+          var exp = __webpack_require__(moduleId);
+
+          // Using babel as a transpiler to use esmodule, the export will always
+          // be an object with the default export as a property of it. To ensure
+          // the existing api and babel esmodule exports are both supported we
+          // check for both
+          if (!(exp && (exp === fn || exp.default === fn))) {
+              sources[moduleId] = wrapperFuncString.substring(0, wrapperFuncString.length - 1) + '\n' + fnString.match(/function\s?(.+?)\s?\(.*/)[1] + '();\n}';
+          }
+
+          return true;
+        }
+
+        return false;
+    });
+
+    if (typeof key === 'undefined') {
+        throw new Error('webworkify-webpack: Could not locate module containing worker function!');
     }
 
     // window = {}; => https://github.com/borisirota/webworkify-webpack/issues/1
     var src = 'window = {};\n'
         + 'var fn = (' + webpackBootstrapFunc.toString().replace('entryModule', key) + ')(['
-        + sourcesKeys.map(function (k) {
-            return sources[k].toString();
-        }).join(',')
+        + moduleWrapperStrings.join(',')
         + ']);\n'
         + '(typeof fn === "function") && fn(self);'; // not a function when calling a function from the current scope
 


### PR DESCRIPTION
There were two things going on:

1) The issue from #14 was that the stringified module code had a space between the `function` and `(`. Going on the comment under `fnString`, we need to take the no-space formatting into account as well, and it's not consistent. Therefore, I split `fnString` into with-space and no-space versions, and check for both of them.

2) The issue with minified code that I saw after #13 was because the minified function actually existed character for character in another module, and was breaking out of the loop before it found the real module. I fixed this by scanning through the module list for any modules that require webworkify-webpack, and noting any modules required from there - these form a whitelist of potential modules that `fn` might exist in.

I also replaced the `sourceKeys.map` at the bottom with a list populated on the first scan through the module list, just to cut back on an extra iteration.
