### PR TITLE
add more info to this error

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = function (fn) {
     });
 
     if (typeof key === 'undefined') {
-        throw new Error('webworkify-webpack: Could not locate module containing worker function!');
+        throw new Error('webworkify-webpack: Could not locate module containing worker function! Make sure you aren\'t using eval sourcemaps!');
     }
 
     // window = {}; => https://github.com/borisirota/webworkify-webpack/issues/1


### PR DESCRIPTION
spent a lot of time trying to figure out why this error was happening, this note on the README was not very visible

`While developing make sure not to set webpack's devtool option to be with some eval configuration because from 1.1.0 version it won't work`

I think this should help people out when they have this problem
