### PR TITLE
Fix module id in webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var __webpack_require__ = arguments[2];
 var sources = __webpack_require__.m;
-var webworkifyWebpackModuleId = arguments[0].id;
+// In webpack 2 the moduleId property is called `i` instead of `id`.
+var webworkifyWebpackModuleId = arguments[0].id || arguments[0].i;
 
 var webpackBootstrapFunc = function(modules) {
     var installedModules = {};


### PR DESCRIPTION
I tried this in a project using webpack 2 but it didn't work, after looking into it found out that the module id was called `i` instead of `id` in webpack 2 so this simply falls back to `i` if `id` doesn't exists. Now it works with webpack 2.
