### PR TITLE
fix regex to recognise \n__webpack__require__

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function getModuleDependencies (module) {
   if (!wrapperSignature) return retval
 
   var webpackRequireName = wrapperSignature[1]
-  var re = new RegExp('(\\\\n|\\\W)' + quoteRegExp(webpackRequireName) + '\\((\/\\*.*?\\*\/)?\s?.*?([\\.|\\-|\\w|\/|@]+).*?\\)', 'g') // additional chars when output.pathinfo is true
+  var re = new RegExp('(\\\\n|\\W)' + quoteRegExp(webpackRequireName) + '\\((\/\\*.*?\\*\/)?\s?.*?([\\.|\\-|\\w|\/|@]+).*?\\)', 'g') // additional chars when output.pathinfo is true
   var match
   while ((match = re.exec(fnString))) {
     retval.push(match[3])

--- a/index.js
+++ b/index.js
@@ -80,10 +80,10 @@ function getModuleDependencies (module) {
   if (!wrapperSignature) return retval
 
   var webpackRequireName = wrapperSignature[1]
-  var re = new RegExp('\\W' + quoteRegExp(webpackRequireName) + '\\((\/\\*.*?\\*\/)?\s?.*?([\\.|\\-|\\w|\/|@]+).*?\\)', 'g') // additional chars when output.pathinfo is true
+  var re = new RegExp('(\\\\n|\\\W)' + quoteRegExp(webpackRequireName) + '\\((\/\\*.*?\\*\/)?\s?.*?([\\.|\\-|\\w|\/|@]+).*?\\)', 'g') // additional chars when output.pathinfo is true
   var match
   while ((match = re.exec(fnString))) {
-    retval.push(match[2])
+    retval.push(match[3])
   }
   return retval
 }


### PR DESCRIPTION
For modules that are required without assigning them to a var:

```
require('babel-pollyfill');
```

webpack 2 generates:

```
\n__webpack_require__(/*! babel-polyfill */ 221);
```

which does not match the existing regex in `getModuleDependencies` because of the lack of whitespace before the `__webpack`.  This PR simply adds to the regex to include such cases, i.e. having a `\n`.

---

For reference, the case that does work is:

```
var thing = require('something');
```

which ends up as:

```
var thing = __webpack_require__(/*! something */ 659);
```