### PR TITLE
Force module to be integer

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function getModuleDependencies (sources, module, queueName) {
   // in such case need to convert 1e3 back to 1000
   var keys = Object.keys(retval);
   for (var i = 0; i < keys.length; i++) {
-    for (var j = 0; j < retval[keys[i]].length; j++) {
+    for (var j = 0; j < retval[keys[i]].length; i++) {
       retval[keys[i]][j] = +retval[keys[i]][j];
     }
   }

--- a/index.js
+++ b/index.js
@@ -111,10 +111,10 @@ function getModuleDependencies (sources, module, queueName) {
 
   // force module to be integer, this can be important after uglify-js converted 1000 to 1e3
   // in such case need to convert 1e3 back to 1000
-  var keys = Object.keys(retVal);
+  var keys = Object.keys(retval);
   for (var i = 0; i < keys.length; i++) {
-    for (var j = 0; j < retVal[keys[i]].length; i++) {
-      retVal[keys[i]][j] = +retVal[keys[i]][j];
+    for (var j = 0; j < retval[keys[i]].length; i++) {
+      retval[keys[i]][j] = +retval[keys[i]][j];
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -81,6 +81,10 @@ function quoteRegExp (str) {
   return (str + '').replace(/[.?*+^$[\]\\(){}|-]/g, '\\$&')
 }
 
+function isNumeric(n) {
+  return !isNaN(1 * n); // 1 * n converts integers, integers as string ("123"), 1e3 and "1e3" to integers and strings to NaN
+}
+
 function getModuleDependencies (sources, module, queueName) {
   var retval = {}
   retval[queueName] = []
@@ -114,7 +118,9 @@ function getModuleDependencies (sources, module, queueName) {
   var keys = Object.keys(retval);
   for (var i = 0; i < keys.length; i++) {
     for (var j = 0; j < retval[keys[i]].length; j++) {
-      retval[keys[i]][j] = +retval[keys[i]][j];
+      if (isNumeric(retval[keys[i]][j])) {
+        retval[keys[i]][j] = 1 * retval[keys[i]][j];
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function getModuleDependencies (sources, module, queueName) {
   // in such case need to convert 1e3 back to 1000
   var keys = Object.keys(retval);
   for (var i = 0; i < keys.length; i++) {
-    for (var j = 0; j < retval[keys[i]].length; i++) {
+    for (var j = 0; j < retval[keys[i]].length; j++) {
       retval[keys[i]][j] = +retval[keys[i]][j];
     }
   }

--- a/index.js
+++ b/index.js
@@ -109,6 +109,15 @@ function getModuleDependencies (sources, module, queueName) {
     retval[match[2]].push(match[4])
   }
 
+  // force module to be integer, this can be important after uglify-js converted 1000 to 1e3
+  // in such case need to convert 1e3 back to 1000
+  var keys = Object.keys(retVal);
+  for (var i = 0; i < keys.length; i++) {
+    for (var j = 0; j < retVal[keys[i]].length; i++) {
+      retVal[keys[i]][j] = +retVal[keys[i]][j];
+    }
+  }
+
   return retval
 }
 


### PR DESCRIPTION
Fix incompatibility with uglify-js.

Notice that uglify-js will convert `__webpack_require__(1000)` to `something(1e3)`. The important conversion here is from 1000 to string "1e3". This feature cannot be easily closed in uglify-js.

Currently the `getModuleDependencies` function grabs the module integer from _fnString_ by regexp. When it runs on a module dependent on module 1000, it should store 1000 beneath some key of `retval`, but the actual value it stores is a string "1e3".

The problem is, both `sources[queueName][moduleToCheck]` in `getRequiredModules`, and `sources[module][id]` in `module.exports` do not recognize string "1e3". They only accept string "1000" or number 1000.

In such case, module 1000 cannot be added to the webworker blob, and the webworker will not run correctly.