### PR TITLE
support named wrapper fn, and require call over multiple lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function getModuleDependencies (sources, module, queueName) {
   var webpackRequireName = wrapperSignature[1]
 
   // main bundle deps
-  var re = new RegExp('[^a-zA-Z\\\\.]' + quoteRegExp(webpackRequireName) + dependencyRegExp, 'g')
+  var re = new RegExp('[^a-zA-Z\\.\\_\\-]' + quoteRegExp(webpackRequireName) + dependencyRegExp, 'g')
   var match
   while ((match = re.exec(fnString))) {
     var moduleName = match[1] || match[2]

--- a/index.js
+++ b/index.js
@@ -99,20 +99,21 @@ function getModuleDependencies (sources, module, queueName) {
   var re = new RegExp(quoteRegExp(webpackRequireName) + dependencyRegExp, 'g')
   var match
   while ((match = re.exec(fnString))) {
-    var chosen = match[1] || match[2]
     if (chosen === 'dll-reference') continue
-    retval[queueName].push(chosen)
+    var moduleName = match[1] || match[2]
+    retval[queueName].push(moduleName)
   }
 
   // dll deps
   re = new RegExp('\\(' + quoteRegExp(webpackRequireName) + '\\("(dll-reference\\s(' + moduleNameReqExp + '))"\\)\\)' + dependencyRegExp, 'g')
   while ((match = re.exec(fnString))) {
+    var moduleName = match[3] || match[4]
     if (!sources[match[2]]) {
       retval[queueName].push(match[1])
       sources[match[2]] = __webpack_require__(match[1]).m
     }
     retval[match[2]] = retval[match[2]] || []
-    retval[match[2]].push(match[4])
+    retval[match[2]].push(moduleName)
   }
 
   // convert 1e3 back to 1000 - this can be important after uglify-js converted 1000 to 1e3

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function getModuleDependencies (sources, module, queueName) {
   var webpackRequireName = wrapperSignature[1]
 
   // main bundle deps
-  var re = new RegExp(quoteRegExp(webpackRequireName) + dependencyRegExp, 'g')
+  var re = new RegExp('[^a-zA-Z\\\\.]' + quoteRegExp(webpackRequireName) + dependencyRegExp, 'g')
   var match
   while ((match = re.exec(fnString))) {
     var moduleName = match[1] || match[2]

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function webpackBootstrapFunc (modules) {
 }
 
 var moduleNameReqExp = '[\\.|\\-|\\+|\\w|\/|@]+'
-var dependencyRegExp = '\\((\/\\*.*?\\*\/)?\s?.*?(' + moduleNameReqExp + ').*?\\)' // additional chars when output.pathinfo is true
+var dependencyRegExp = '\\([\\S\\s]*?"(' + moduleNameReqExp + ')"[\\S\\s]*?\\)' // additional chars when output.pathinfo is true
 var wrapperSignatureRegExp = /^function(?: \w+)?\s?\(\w+,\s*\w+,\s*(\w+)\)/
 
 // http://stackoverflow.com/a/2593661/130442
@@ -96,11 +96,11 @@ function getModuleDependencies (sources, module, queueName) {
   var webpackRequireName = wrapperSignature[1]
 
   // main bundle deps
-  var re = new RegExp('(\\\\n|\\W)' + quoteRegExp(webpackRequireName) + dependencyRegExp, 'g')
+  var re = new RegExp(quoteRegExp(webpackRequireName) + dependencyRegExp, 'g')
   var match
   while ((match = re.exec(fnString))) {
-    if (match[3] === 'dll-reference') continue
-    retval[queueName].push(match[3])
+    if (match[1] === 'dll-reference') continue
+    retval[queueName].push(match[1])
   }
 
   // dll deps

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function webpackBootstrapFunc (modules) {
 }
 
 var moduleNameReqExp = '[\\.|\\-|\\+|\\w|\/|@]+'
-var dependencyRegExp = '\\([\\S\\s]*?(?:(?=\\d)(' + moduleNameReqExp + ')|"(' + moduleNameReqExp + ')")[\\S\\s]*?\\)' // additional chars when output.pathinfo is true
+var dependencyRegExp = '\\((?:(?=\\d)(' + moduleNameReqExp + ')|[\\S\\s]*?"(' + moduleNameReqExp + ')"[\\S\\s]*?)\\)' // additional chars when output.pathinfo is true
 var wrapperSignatureRegExp = /^function(?: \w+)?\s?\(\w+,\s*\w+,\s*(\w+)\)/
 
 // http://stackoverflow.com/a/2593661/130442

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function webpackBootstrapFunc (modules) {
 }
 
 var moduleNameReqExp = '[\\.|\\-|\\+|\\w|\/|@]+'
-var dependencyRegExp = '\\([\\S\\s]*?"(' + moduleNameReqExp + ')"[\\S\\s]*?\\)' // additional chars when output.pathinfo is true
+var dependencyRegExp = '\\([\\S\\s]*?(?:(?=\\d)(' + moduleNameReqExp + ')|"(' + moduleNameReqExp + ')")[\\S\\s]*?\\)' // additional chars when output.pathinfo is true
 var wrapperSignatureRegExp = /^function(?: \w+)?\s?\(\w+,\s*\w+,\s*(\w+)\)/
 
 // http://stackoverflow.com/a/2593661/130442
@@ -99,8 +99,9 @@ function getModuleDependencies (sources, module, queueName) {
   var re = new RegExp(quoteRegExp(webpackRequireName) + dependencyRegExp, 'g')
   var match
   while ((match = re.exec(fnString))) {
-    if (match[1] === 'dll-reference') continue
-    retval[queueName].push(match[1])
+    var chosen = match[1] || match[2]
+    if (chosen === 'dll-reference') continue
+    retval[queueName].push(chosen)
   }
 
   // dll deps

--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ function webpackBootstrapFunc (modules) {
 
 var moduleNameReqExp = '[\\.|\\-|\\+|\\w|\/|@]+'
 var dependencyRegExp = '\\((\/\\*.*?\\*\/)?\s?.*?(' + moduleNameReqExp + ').*?\\)' // additional chars when output.pathinfo is true
+var wrapperSignatureRegExp = /^function(?: \w+)?\s?\(\w+,\s*\w+,\s*(\w+)\)/
 
 // http://stackoverflow.com/a/2593661/130442
 function quoteRegExp (str) {
@@ -90,7 +91,7 @@ function getModuleDependencies (sources, module, queueName) {
   retval[queueName] = []
 
   var fnString = module.toString()
-  var wrapperSignature = fnString.match(/^function\s?\(\w+,\s*\w+,\s*(\w+)\)/)
+  var wrapperSignature = fnString.match(wrapperSignatureRegExp)
   if (!wrapperSignature) return retval
   var webpackRequireName = wrapperSignature[1]
 

--- a/index.js
+++ b/index.js
@@ -99,8 +99,8 @@ function getModuleDependencies (sources, module, queueName) {
   var re = new RegExp(quoteRegExp(webpackRequireName) + dependencyRegExp, 'g')
   var match
   while ((match = re.exec(fnString))) {
-    if (chosen === 'dll-reference') continue
     var moduleName = match[1] || match[2]
+    if (moduleName === 'dll-reference') continue
     retval[queueName].push(moduleName)
   }
 


### PR DESCRIPTION
The config that [`create-react-app`](https://github.com/facebook/create-react-app) uses causes the wrapper function to be named, and the require calls to break onto multiple lines.

This PR adds support for that.

e.g.
support
```js
function srcDemuxDemuxerWorkerJs(module, __webpack_exports__, __webpack_require__) {
```
in addition to
```js
function(module, __webpack_exports__, __webpack_require__) {
```
and

```js
var _demux_demuxer_inline__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(
        /*! ../demux/demuxer-inline */
        "./src/demux/demuxer-inline.js");
```
in addition to
```js
var _demux_demuxer_inline__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../demux/demuxer-inline */ "./src/demux/demuxer-inline.js");
```

ref https://github.com/video-dev/hls.js/issues/2064